### PR TITLE
Allow curl to use HTTP/2

### DIFF
--- a/src/p3k/HTTP/Curl.php
+++ b/src/p3k/HTTP/Curl.php
@@ -5,6 +5,7 @@ class Curl implements Transport {
 
   protected $_timeout = 4;
   protected $_max_redirects = 8;
+  static protected $_http_version = null;
 
   public function set_max_redirects($max) {
     $this->_max_redirects = $max;
@@ -79,6 +80,20 @@ class Curl implements Transport {
     curl_setopt($ch, CURLOPT_MAXREDIRS, $this->_max_redirects);
     curl_setopt($ch, CURLOPT_TIMEOUT_MS, round($this->_timeout * 1000));
     curl_setopt($ch, CURLOPT_CONNECTTIMEOUT_MS, 2000);
+    curl_setopt($ch, CURLOPT_HTTP_VERSION, $this->_http_version());
+  }
+
+  private function _http_version() {
+    if (static::$_http_version !== null)
+      return static::$_http_version;
+    if (defined('CURL_HTTP_VERSION_2')) { // PHP 7.0.7
+      static::$_http_version = CURL_HTTP_VERSION_2;
+    } else if (defined('CURL_HTTP_VERSION_2_0')) { // Recommended in online articles
+      static::$_http_version = CURL_HTTP_VERSION_2_0;
+    } else { // Linked curl might be newer than PHP, send (current) INT value anyway.
+      static::$_http_version = 3;
+    }
+    return static::$_http_version;
   }
 
   public static function error_string_from_code($code) {


### PR DESCRIPTION
Even if PHP is linked to a curl executable that support HTTP/2 (e.g. from brew with `--with-nghttp2`) it will not automatically do HTTP/2.

For this we need to define a value for `CURLOPT_HTTP_VERSION`. If curl is too old to understand it, nothing will happen defining this, so it degrades gracefully. As of PHP 7.0.7 there is a constant we can use (`CURL_HTTP_VERSION_2`) and other sources online (e.g. [StackOverflow](https://stackoverflow.com/a/37146586) and [PHP Contributed Notes](https://php.net/manual/en/curl.constants.php#122014)) mention a second one we can try to use (`CURL_HTTP_VERSION_2_0`).

If neither exists we pass the current INT value behind these constants: `3`.

If a website does not support HTTP/2, curl will automatically fallback to 1 or 1.1, so again, nothing should break with this change.