### PR TITLE
Track redirects followed by curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The get/post/head functions will return an array with the following properties:
 * `headers` - array, the HTTP headers returned
 * `rels` - array, the parsed HTTP rel values from any `Link` headers
 * `body` - string, the body of the HTTP response, or false/omit for a HEAD request
+* `redirects` - array, the redirects followed, or omitted when not supported
 * `error` - string, an error string. see below for the enumerated list.
 * `error_description` - string,
 * `url` - string, the final URL retrieved after following any redirects
@@ -112,6 +113,31 @@ The `rels` key will be the parsed version of any HTTP `Link` headers that contai
         )
 ```
 
+#### `redirects`
+
+The `redirects` key will be an array of all the redirects followed to retrieve the final response. This key may be omitted if the transport does not support retrieving the data.
+
+```php
+Array
+(
+    [0] => Array
+        (
+            [code] => 301
+            [from] => http://aaronpk.com/
+            [to] => https://aaronpk.com/
+        )
+
+    [1] => Array
+        (
+            [code] => 301
+            [from] => https://aaronpk.com/
+            [to] => https://aaronparecki.com/
+        )
+
+)
+```
+
+The `code` key within a redirect array is the HTTP status code that came with it. This can be used for separating permanent redirects (301) from temporary ones (302).
 
 ### Options
 

--- a/src/p3k/HTTP/Curl.php
+++ b/src/p3k/HTTP/Curl.php
@@ -6,6 +6,10 @@ class Curl implements Transport {
   protected $_timeout = 4;
   protected $_max_redirects = 8;
   static protected $_http_version = null;
+  private $_last_seen_url = null;
+  private $_last_seen_code = null;
+  private $_current_headers = [];
+  private $_current_redirects = [];
 
   public function set_max_redirects($max) {
     $this->_max_redirects = $max;
@@ -21,16 +25,14 @@ class Curl implements Transport {
     if($headers)
       curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
     $response = curl_exec($ch);
-    $header_size = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
-    $header_str = trim(substr($response, 0, $header_size));
     return [
       'code' => curl_getinfo($ch, CURLINFO_HTTP_CODE),
-      'header' => $header_str,
-      'body' => substr($response, $header_size),
+      'header' => implode("\r\n", array_map(function ($a) { return $a[0] . ': ' . $a[1]; }, $this->_current_headers)),
+      'body' => $response,
+      'redirects' => $this->_current_redirects,
       'error' => self::error_string_from_code(curl_errno($ch)),
       'error_description' => curl_error($ch),
-      'url' => curl_getinfo($ch, CURLINFO_EFFECTIVE_URL),
-      'debug' => $response
+      'url' => $this->_last_seen_url
     ];
   }
 
@@ -42,16 +44,14 @@ class Curl implements Transport {
     if($headers)
       curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
     $response = curl_exec($ch);
-    $header_size = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
-    $header_str = trim(substr($response, 0, $header_size));
     return [
       'code' => curl_getinfo($ch, CURLINFO_HTTP_CODE),
-      'header' => $header_str,
-      'body' => substr($response, $header_size),
+      'header' => implode("\r\n", array_map(function ($a) { return $a[0] . ': ' . $a[1]; }, $this->_current_headers)),
+      'body' => $response,
+      'redirects' => $this->_current_redirects,
       'error' => self::error_string_from_code(curl_errno($ch)),
       'error_description' => curl_error($ch),
-      'url' => curl_getinfo($ch, CURLINFO_EFFECTIVE_URL),
-      'debug' => $response
+      'url' => $this->_last_seen_url
     ];
   }
 
@@ -64,23 +64,22 @@ class Curl implements Transport {
     $response = curl_exec($ch);
     return [
       'code' => curl_getinfo($ch, CURLINFO_HTTP_CODE),
-      'header' => trim($response),
+      'header' => implode("\r\n", array_map(function ($a) { return $a[0] . ': ' . $a[1]; }, $this->_current_headers)),
+      'redirects' => $this->_current_redirects,
       'error' => self::error_string_from_code(curl_errno($ch)),
       'error_description' => curl_error($ch),
-      'url' => curl_getinfo($ch, CURLINFO_EFFECTIVE_URL),
-      'debug' => $response
+      'url' => $this->_last_seen_url
     ];
   }
 
   private function _set_curlopts($ch, $url) {
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-    curl_setopt($ch, CURLOPT_HEADER, true);
-    if($this->_max_redirects > 0)
-      curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, $this->_max_redirects > 0);
     curl_setopt($ch, CURLOPT_MAXREDIRS, $this->_max_redirects);
     curl_setopt($ch, CURLOPT_TIMEOUT_MS, round($this->_timeout * 1000));
     curl_setopt($ch, CURLOPT_CONNECTTIMEOUT_MS, 2000);
     curl_setopt($ch, CURLOPT_HTTP_VERSION, $this->_http_version());
+    curl_setopt($ch, CURLOPT_HEADERFUNCTION, [$this, '_header_function']);
   }
 
   private function _http_version() {
@@ -94,6 +93,25 @@ class Curl implements Transport {
       static::$_http_version = 3;
     }
     return static::$_http_version;
+  }
+
+  private function _header_function($curl, $header) {
+    $current_url = curl_getinfo($curl, CURLINFO_EFFECTIVE_URL);
+    if ($current_url !== $this->_last_seen_url) {
+        if ($this->_last_seen_url !== null) {
+            $this->_current_redirects[] = [$this->_last_seen_code, $this->_last_seen_url];
+        }
+        $this->_current_headers = [];
+        $this->_last_seen_url = $current_url;
+        $this->_last_seen_code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+    }
+    $length = strlen($header);
+    $header = explode(':', $header, 2);
+    if (count($header) !== 2) {
+      return $length;
+    }
+    $this->_current_headers[] = array_map('trim', [$header[0], $header[1]]);
+    return $length;
   }
 
   public static function error_string_from_code($code) {

--- a/src/p3k/HTTP/Curl.php
+++ b/src/p3k/HTTP/Curl.php
@@ -104,7 +104,13 @@ class Curl implements Transport {
     $current_url = curl_getinfo($curl, CURLINFO_EFFECTIVE_URL);
     if ($current_url !== $this->_last_seen_url) {
         if ($this->_last_seen_url !== null) {
-            $this->_current_redirects[] = [$this->_last_seen_code, $this->_last_seen_url];
+            $this->_current_redirects[] = [
+                'code' => $this->_last_seen_code,
+                'from' => $this->_last_seen_url,
+                'to' => $current_url,
+            ];
+        } else {
+            $this->_current_redirects = [];
         }
         $this->_current_headers = [];
         $this->_last_seen_url = $current_url;

--- a/src/p3k/HTTP/Curl.php
+++ b/src/p3k/HTTP/Curl.php
@@ -10,6 +10,7 @@ class Curl implements Transport {
   private $_last_seen_code = null;
   private $_current_headers = [];
   private $_current_redirects = [];
+  private $_debug_header = '';
 
   public function set_max_redirects($max) {
     $this->_max_redirects = $max;
@@ -32,7 +33,8 @@ class Curl implements Transport {
       'redirects' => $this->_current_redirects,
       'error' => self::error_string_from_code(curl_errno($ch)),
       'error_description' => curl_error($ch),
-      'url' => $this->_last_seen_url
+      'url' => $this->_last_seen_url,
+      'debug' => $this->_debug_header . "\r\n" . $response
     ];
   }
 
@@ -51,7 +53,8 @@ class Curl implements Transport {
       'redirects' => $this->_current_redirects,
       'error' => self::error_string_from_code(curl_errno($ch)),
       'error_description' => curl_error($ch),
-      'url' => $this->_last_seen_url
+      'url' => $this->_last_seen_url,
+      'debug' => $this->_debug_header . "\r\n" . $response
     ];
   }
 
@@ -68,7 +71,8 @@ class Curl implements Transport {
       'redirects' => $this->_current_redirects,
       'error' => self::error_string_from_code(curl_errno($ch)),
       'error_description' => curl_error($ch),
-      'url' => $this->_last_seen_url
+      'url' => $this->_last_seen_url,
+      'debug' => $this->_debug_header . "\r\n" . $response
     ];
   }
 
@@ -96,6 +100,7 @@ class Curl implements Transport {
   }
 
   private function _header_function($curl, $header) {
+    $this->_debug_header .= $header;
     $current_url = curl_getinfo($curl, CURLINFO_EFFECTIVE_URL);
     if ($current_url !== $this->_last_seen_url) {
         if ($this->_last_seen_url !== null) {


### PR DESCRIPTION
Three commits:

1. Implement a `CURLOPT_HEADERFUNCTION` that keeps track of all headers coming in, and when curl switches to a different URL logs this as a redirect.
   
2. Reimplement the `debug` property coming out of the transport, because the `CURLOPT_HEADERFUNCTION` took all headers away from the standard response. As all lines parsed by the header function can be added to debug now, it will actually show all responses (with their headers) along the redirect path. In a way it has become even more complete.

3. Use [the syntax](https://github.com/aaronpk/indielogin.com/blob/bfba930c3f1b1797802007873a1e73d82c7a2687/lib/helpers.php#L104-L108) expected by [aaronpk/indielogin.com](https://github.com/aaronpk/indielogin.com) for the redirect array:
   ```php
    $redirects[] = [
      'code' => $response->getStatusCode(),
      'from' => ''.$request->getUri(),
      'to' => ''.$uri
    ];
   ```

All of this is also detailed in the commit messages.